### PR TITLE
Fix version key format

### DIFF
--- a/custom_components/bmw_connected_drive/manifest.json
+++ b/custom_components/bmw_connected_drive/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["bimmer_connected"],
   "requirements": ["bimmer_connected==0.13.0"],
-  "version": "2023.3-custom"
+  "version": "2023.3.12"
 }


### PR DESCRIPTION
Evidently, to load a custom component, the version key has to be a string with a major, minor and patch version separated by periods ("."). For example, "1.2.3":

  https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions