### PR TITLE
Remove `-custom` from version number

### DIFF
--- a/.github/workflows/reset_to_ha.yml
+++ b/.github/workflows/reset_to_ha.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Copy component from HA into workspace
         run: |
           cd ${{ github.workspace }}/custom_components/bmw_connected_drive
-          sed -i "$(($(wc -l < manifest.json) - 1))i\\  \"version\": \"${{ env.HA_VERSION }}-custom\",\\" manifest.json
+          sed -i "$(($(wc -l < manifest.json) - 1))i\\  \"version\": \"${{ env.HA_VERSION }}\",\\" manifest.json
 
       - name: Create PR with new changes
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/reset_to_ha.yml
+++ b/.github/workflows/reset_to_ha.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.temp }}/core/homeassistant/components/bmw_connected_drive/ \
             ${{ github.workspace }}/custom_components/bmw_connected_drive
 
-      - name: Copy component from HA into workspace
+      - name: Update version number
         run: |
           cd ${{ github.workspace }}/custom_components/bmw_connected_drive
           sed -i "$(($(wc -l < manifest.json) - 1))i\\  \"version\": \"${{ env.HA_VERSION }}\",\\" manifest.json


### PR DESCRIPTION
As described in #57 we should comply to the version number format from [HA](https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions).